### PR TITLE
Add dependencySupport entry

### DIFF
--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,5 +11,7 @@
     <idea-version since-build="233"/>
     <extensions defaultExtensionNs="com.intellij">
         <lang.psiAugmentProvider implementation="net.staticstudios.data.ide.intellij.DataPsiAugmentProvider"/>
+
+        <dependencySupport coordinate="net.staticstudios:static-data" kind="java" displayName="Static Data"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
In theory this should make it possible for the plugin to be suggested by intelliJ when the project has static data as dependency configured